### PR TITLE
Only permit a single retry for now api

### DIFF
--- a/app/features/shared/components/navigation/Navbar.jsx
+++ b/app/features/shared/components/navigation/Navbar.jsx
@@ -20,7 +20,7 @@ export const Navbar = () => {
     return isMobile();
   }, []);
 
-  const { data, isLoading, error } = useCurrentStoreStateQuery();
+  const { data, isLoading } = useCurrentStoreStateQuery();
 
   return (
     <div
@@ -103,8 +103,10 @@ export const Navbar = () => {
         className="sm:text-base text-sm flex flex-col sm:flex-row justify-center sm:gap-2 min-w-screen lg:max-w-5xl 2xl:max-w-7xl lg:mx-auto mx-4 my-1 py-1 bg-jt-grad text-black rounded-box z-50"
       >
         <div className="h-8 flex flex-row items-center justify-center gap-1">
-          <Show when={!isLoading && !error} else={
-            <div className="h-4 rounded-md skeleton w-72" style={{ backgroundColor: "rgba(0, 0, 0, 0.3)"}} data-theme="dark" />
+          <Show when={data} else={
+            <Show when={isLoading}>
+              <div className="h-4 rounded-md skeleton w-72" style={{ backgroundColor: "rgba(0, 0, 0, 0.3)"}} data-theme="dark" />
+            </Show>
           }>
             <div style={{ fontWeight: 800 }}>
               {data?.nowMessage}

--- a/app/features/shared/queries/hours.ts
+++ b/app/features/shared/queries/hours.ts
@@ -4,6 +4,7 @@ export const useCurrentStoreStateQuery = () => {
     return useQuery({
         queryKey: ['currentStoreState'],
         queryFn: () => getCurrentStoreState(),
+        retry: 1,
     })
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Limit the store-state query to a single retry and simplify the navbar ticker to render based on data/loading only.
> 
> - **Shared Query (`app/features/shared/queries/hours.ts`)**:
>   - Add `retry: 1` to `useCurrentStoreStateQuery`.
> - **Navbar (`app/features/shared/components/navigation/Navbar.jsx`)**:
>   - Simplify ticker rendering: remove `error` handling and render when `data` exists; show skeleton only while `isLoading`.
>   - Stop destructuring `error` from `useCurrentStoreStateQuery`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3b559793c78c92df4cf062cd9455b695746a252. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->